### PR TITLE
new collider should have prefabRef's runtime properties

### DIFF
--- a/Scripts/AvatarArmatureColliderManager.cs
+++ b/Scripts/AvatarArmatureColliderManager.cs
@@ -138,6 +138,10 @@ namespace JetDog.UserCollider
         {
             AvatarArmatureColliderSystem newCollider = Instantiate(prefabRef.gameObject, Vector3.zero, Quaternion.identity).GetComponent<AvatarArmatureColliderSystem>();
             newCollider.SetUser(player);
+            newCollider.DetectCollision = prefabRef.DetectCollision;
+            newCollider.ColliderIsTrigger = prefabRef.ColliderIsTrigger;
+            newCollider.IncludeLayers = prefabRef.IncludeLayers;
+            newCollider.ExcludeLayers = prefabRef.ExcludeLayers;
 
 
             if (player.isLocal)


### PR DESCRIPTION
SerializeField values that is runtime changed in runtime are not reflected to a instantiated object so manualy set it.

Or maybe it would be better to create `AvatarArmatureColliderManager.LocalIncludeLayers` etc. as ColliderLayer does?
...Or OnAvatarColliderCreated event?