### PR TITLE
prevent GetComponentInParent on CollisionOwnershipTransfer

### DIFF
--- a/Scripts/CollisionOwnershipTransfer.cs
+++ b/Scripts/CollisionOwnershipTransfer.cs
@@ -18,13 +18,12 @@ namespace JetDog.UserCollider
 
         private void OnCollisionEnter(Collision collision)
         {
-            GameObject collidedGOBJ = collision.gameObject;
-            if (!enabled || !Utilities.IsValid(collidedGOBJ)) return;
+            if (!enabled || collision.rigidbody == null) return;
 
-            VRCObjectSync objSync = (VRCObjectSync)collidedGOBJ.GetComponentInParent(typeof(VRCObjectSync));
+            VRCObjectSync objSync = (VRCObjectSync)collision.rigidbody.GetComponent(typeof(VRCObjectSync));
             if (objSync == null) return;
 
-            collidedGOBJ = objSync.gameObject;
+            GameObject collidedGOBJ = objSync.gameObject;
             if (Networking.IsOwner(collidedGOBJ)) return;
 
             VRCPickup pickup = (VRCPickup)objSync.GetComponent(typeof(VRCPickup));

--- a/Scripts/CollisionOwnershipTransfer.cs
+++ b/Scripts/CollisionOwnershipTransfer.cs
@@ -21,7 +21,7 @@ namespace JetDog.UserCollider
             if (!enabled || collision.rigidbody == null) return;
 
             VRCObjectSync objSync = (VRCObjectSync)collision.rigidbody.GetComponent(typeof(VRCObjectSync));
-            if (objSync == null) return;
+            if (objSync == null || !objSync.AllowCollisionOwnershipTransfer) return;
 
             GameObject collidedGOBJ = objSync.gameObject;
             if (Networking.IsOwner(collidedGOBJ)) return;


### PR DESCRIPTION
I think that collision ownership transfer is needed only when the opponent collider is a RigidBody.

- has RigidBody with VRCObjectSync: collision ownership transfer is needed.
- VRCObjectSync that has no RigidBody: it also has no VRCPickup and it cannot be moved by physics or pickup so I think collision ownership transfer is not needed.
- has RigidBody but the VRCObjectSync is attached to different GameObject: weird case.
